### PR TITLE
Add on-short-runway signal and remaining-distance signal during RTO

### DIFF
--- a/Nasal/runway.nas
+++ b/Nasal/runway.nas
@@ -65,6 +65,10 @@ var switch_to_takeoff = func {
     if (takeoff_announcer.mode == "taxi-and-takeoff") {
         takeoff_announcer.set_mode("takeoff");
 #        logger.warn(sprintf("Takeoff mode: %s", takeoff_announcer.mode));
+
+        landing_announcer.set_mode("takeoff");
+        landing_announcer.start();
+#        logger.warn("Starting landing announce");
     }
 };
 
@@ -126,9 +130,10 @@ var test_on_ground = func (on_ground) {
             have_been_in_air = 0;
 
             takeoff_announcer.set_mode("");
+#            logger.warn(sprintf("Takeoff mode: %s", takeoff_announcer.mode));
 
-            landing_announcer.start();
             landing_announcer.set_mode("landing");
+            landing_announcer.start();
 #            logger.warn("Starting landing announce");
         }
     }


### PR DESCRIPTION
- Added on-short-runway signal
- Allow on(-short)-runway anywhere on runway instead of just within 600 meters of the start
- on-short-runway is used to display something like "On runway 24, 2500 meter remaining" if remaining distance (because runway is short for example) is less than 3000 meter
- Set takeoff_config.nominal_distance_takeoff_m to the takeoff distance you usually need. By default it is 3000 meter
- Added remaining-distance signal during RTO. Required conditions:
  - Groundspeed must be at least 40 knots and 7 knots below the maximum attained groundspeed
  - Aircraft must be past 50 % of runway
