### PR TITLE
Automatically control speed under VNAV mode of AFDS

### DIFF
--- a/Nasal/AFDS.nas
+++ b/Nasal/AFDS.nas
@@ -372,12 +372,26 @@ var AFDS = {
 
             if ((idx==5)or(idx==12))
             {
+		if (me.at1.getBoolValue() and getprop("position/altitude-agl-ft") > 200) {
+        	    me.autothrottle_mode.setValue(5);
+		}
+		me.ias_mach_selected.setBoolValue(0);
+		if (getprop("instrumentation/altimeter/indicated-altitude-ft") < 10000) {
+		    me.ias_setting.setValue(250);
+		} else {
+                    me.ias_setting.setValue(280);
+		}
+
                 me.vnav_alt.setValue(me.FMS_alt.getValue());
                 me.alt_setting.setValue(me.FMS_alt.getValue());
                 # flight level change mode (VNAV)
                 if (abs(getprop("instrumentation/altimeter/indicated-altitude-ft")-me.vnav_alt.getValue())<50) {
                     # within target altitude: switch to VNAV ALT mode
                     idx=5;
+		    if (getprop("instrumentation/altimeter/indicated-altitude-ft") >= 34800) {
+			me.ias_mach_selected.setBoolValue(1);
+                    	me.mach_setting.setValue(0.845);
+		    }
                 } else {
                     # outside target altitude: change flight level
 		    me.alt_display.setValue(me.FMS_alt.getValue());

--- a/Systems/747-8-autopilot.xml
+++ b/Systems/747-8-autopilot.xml
@@ -552,7 +552,7 @@
         <value>-16.67</value>
       </u_min>
       <u_max>
-        <value>33.33</value>
+        <value>16.67</value>
       </u_max>
     </config>
   </pi-simple-controller>
@@ -622,7 +622,7 @@
         <value>-16.67</value>
       </u_min>
       <u_max>
-        <value>33.33</value>
+        <value>16.67</value>
       </u_max>
     </config>
   </pi-simple-controller>


### PR DESCRIPTION
Hi,
I would like to add a feature of automatically updating the target speed under VNAV mode, which is similar to the way that Boeing 777's VNAV mode does:
- When the altitude is under 10000ft, set target speed as 250kts.
- When the altitude is above 10000ft and the aircraft is climbing/descending, set target speed as 280kts.
- When the aircraft reaches the target altitude and the altitude is above 34800ft, set target speed as mach 0.845.

PS: In my update, the vertical speed under VNAV mode is always 1000ft/min for climbing and -1000ft/min for descending.